### PR TITLE
Fix incorrect usage of "File.pathSeparator" instead of "File.separator"

### DIFF
--- a/src/main/java/com/amazonaws/ant/s3/DownloadFileFromS3Task.java
+++ b/src/main/java/com/amazonaws/ant/s3/DownloadFileFromS3Task.java
@@ -128,7 +128,9 @@ public class DownloadFileFromS3Task extends AWSAntTask {
                 + " from bucket " + bucketName + " to file " + file + "...");
         try {
             if (file.getParentFile() != null) {
-                file.getParentFile().mkdirs();
+                if(!file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
+                    throw new BuildException("Could not create directory " + file.getParentFile());
+                }
             }
             file.createNewFile();
         } catch (IOException e) {
@@ -136,6 +138,7 @@ public class DownloadFileFromS3Task extends AWSAntTask {
                     "IOException while attempting to create new file " + file + ": "
                             + e.getMessage());
         }
+
         try {
             client.getObject(new GetObjectRequest(bucketName, key), file);
         } catch (Exception e) {
@@ -162,7 +165,7 @@ public class DownloadFileFromS3Task extends AWSAntTask {
                     String key = objectSummary.getKey();
                     if (key.startsWith(keyPrefix)) {
                         downloadObjectToFile(client, new File(dir
-                                + File.pathSeparator + key), key);
+                                + File.separator + key), key);
                     }
                 }
 

--- a/src/test/java/com/amazonaws/ant/s3/DownloadFromS3TaskTests.java
+++ b/src/test/java/com/amazonaws/ant/s3/DownloadFromS3TaskTests.java
@@ -39,8 +39,7 @@ public class DownloadFromS3TaskTests {
     private static final String KEY_PREFIX = "deployfilesettos3test/";
     private static final String TESTFILE_SUFFIX = ".txt";
     private static final String USER_DIR = System.getProperty("user.dir");
-    private static final String DIR = USER_DIR + File.pathSeparator
-            + KEY_PREFIX;
+    private static final String DIR = USER_DIR + File.separator + KEY_PREFIX;
     private static File testFile1, testFile2, testFile3;
     private static AmazonS3Client client;
     private File resFile1, resFile2, resFile3;


### PR DESCRIPTION
File.pathSeparator is actually ";" on Windows and ":" on Linux, I think the code here wanted to use "\" on Windows and "/" on Linux, which is actually File.separator
